### PR TITLE
Fix agent user input new string, discovered do not need empty string …

### DIFF
--- a/ruby/alias_manager.rb
+++ b/ruby/alias_manager.rb
@@ -33,7 +33,7 @@ secret_agent = {
 	agent: [],
 	converted: []
 }
-agent = ""
+
 final_name = ""
 restart = ""
 


### PR DESCRIPTION
…bc first time called it's defined by gets.chomp, otherwise restart needs empty string because called in until loop